### PR TITLE
Add background animation with profile toggle

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,8 @@
     "react-native-safe-area-context": "^5.4.1",
     "react-native-screens": "^4.11.1",
     "react-native-web": "^0.20.0",
-    "expo-dev-client": "~5.2.0"
+    "expo-dev-client": "~5.2.0",
+    "lottie-react-native": "^7.2.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/app/src/components/BackgroundAnimation.js
+++ b/app/src/components/BackgroundAnimation.js
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react';
+import { StyleSheet } from 'react-native';
+import LottieView from 'lottie-react-native';
+import { AppContext } from '../context/AppContext';
+
+const remoteSource = {
+  uri: 'https://assets10.lottiefiles.com/packages/lf20_u4yrau.json',
+};
+
+export default function BackgroundAnimation() {
+  const { animationEnabled } = useContext(AppContext);
+  if (!animationEnabled) return null;
+  return (
+    <LottieView
+      source={remoteSource}
+      autoPlay
+      loop
+      style={[StyleSheet.absoluteFill, styles.anim]}
+      resizeMode="cover"
+      pointerEvents="none"
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  anim: { zIndex: -1 },
+});

--- a/app/src/context/AppContext.js
+++ b/app/src/context/AppContext.js
@@ -84,6 +84,7 @@ export const AppProvider = ({ children }) => {
   const [notificationSettings, setNotificationSettings] = useState(
     initialNotificationSettings
   );
+  const [animationEnabled, setAnimationEnabled] = useState(true);
   const claimReward = () => {
     setPendingReward(null);
     setAnalytics((a) => ({ ...a, rewardsClaimed: a.rewardsClaimed + 1 }));
@@ -97,11 +98,14 @@ export const AppProvider = ({ children }) => {
         const storedTheme = await AsyncStorage.getItem('theme');
         const storedNotify = await AsyncStorage.getItem('notify');
         const storedFeedback = await AsyncStorage.getItem('feedbackLogs');
+        const storedAnimation = await AsyncStorage.getItem('animation');
         if (storedTasks) setTasks(JSON.parse(storedTasks));
         if (storedAnalytics) setAnalytics(JSON.parse(storedAnalytics));
         if (storedTheme) setTheme(storedTheme);
         if (storedNotify) setNotificationSettings(JSON.parse(storedNotify));
         if (storedFeedback) setFeedbackLogs(JSON.parse(storedFeedback));
+        if (storedAnimation !== null)
+          setAnimationEnabled(storedAnimation === 'true');
       } catch (e) {
         setError('Failed to load data');
       } finally {
@@ -119,12 +123,21 @@ export const AppProvider = ({ children }) => {
         await AsyncStorage.setItem('theme', theme);
         await AsyncStorage.setItem('notify', JSON.stringify(notificationSettings));
         await AsyncStorage.setItem('feedbackLogs', JSON.stringify(feedbackLogs));
+        await AsyncStorage.setItem('animation', animationEnabled.toString());
       } catch (e) {
         setError('Failed to save data');
       }
     };
     if (!loading) save();
-  }, [tasks, analytics, theme, notificationSettings, feedbackLogs, loading]);
+  }, [
+    tasks,
+    analytics,
+    theme,
+    notificationSettings,
+    feedbackLogs,
+    animationEnabled,
+    loading,
+  ]);
 
   const updatePreference = (name, preference) => {
     setUsers((prev) =>
@@ -268,6 +281,8 @@ export const AppProvider = ({ children }) => {
         notificationSettings,
         updateNotificationSettings,
         logFeedback,
+        animationEnabled,
+        setAnimationEnabled,
       }}
     >
       {children}

--- a/app/src/screens/HomeScreen.js
+++ b/app/src/screens/HomeScreen.js
@@ -2,6 +2,7 @@ import React, { useContext, useState } from 'react';
 import { View, Text, StyleSheet, Button, Modal, ActivityIndicator, Pressable } from 'react-native';
 import { AppContext } from '../context/AppContext';
 import { ProgressBar } from '../components/ProgressBar';
+import BackgroundAnimation from '../components/BackgroundAnimation';
 
 export default function HomeScreen({ navigation }) {
   const {
@@ -38,6 +39,7 @@ export default function HomeScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
+      <BackgroundAnimation />
       <Text style={styles.title}>Resident's Adventure Engine</Text>
       <ProgressBar progress={progress} color={theme} />
       <Text style={styles.tokens}>Tokens: {tokens}</Text>

--- a/app/src/screens/ProfileScreen.js
+++ b/app/src/screens/ProfileScreen.js
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   ScrollView,
   TextInput,
+  Switch,
   Pressable,
   Share,
   Linking,
@@ -25,6 +26,8 @@ export default function ProfileScreen() {
     updateNotificationSettings,
     feedbackLogs,
     logFeedback,
+    animationEnabled,
+    setAnimationEnabled,
   } = useContext(AppContext);
 
   const [hour, setHour] = useState(notificationSettings.hour.toString());
@@ -90,6 +93,13 @@ export default function ProfileScreen() {
           </Text>
         )}
       </View>
+
+      <Text style={styles.sectionTitle}>Background Animation</Text>
+      <Switch
+        value={animationEnabled}
+        onValueChange={setAnimationEnabled}
+        accessibilityLabel="Toggle background animation"
+      />
 
       <Text style={styles.sectionTitle}>Theme</Text>
       <View style={styles.themeRow}>


### PR DESCRIPTION
## Summary
- include Lottie dependency
- store animationEnabled preference in context and AsyncStorage
- show subtle Lottie animation on Home screen
- allow users to toggle the animation in the Profile screen

## Testing
- `npm test --silent --prefix app`

------
https://chatgpt.com/codex/tasks/task_e_6847291f8fd8832a92648cf0ca0c3064