### PR TITLE
Add dark and light theming

### DIFF
--- a/app/src/context/AppContext.js
+++ b/app/src/context/AppContext.js
@@ -2,6 +2,19 @@ import React, { createContext, useState, useEffect } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Notifications from 'expo-notifications';
 
+const palettes = {
+  light: {
+    background: '#ffffff',
+    text: '#000000',
+    button: '#2196f3',
+  },
+  dark: {
+    background: '#121212',
+    text: '#ffffff',
+    button: '#bb86fc',
+  },
+};
+
 const initialTasks = [
   {
     id: 1,
@@ -80,7 +93,9 @@ export const AppProvider = ({ children }) => {
   const [error, setError] = useState(null);
   const [analytics, setAnalytics] = useState(initialAnalytics);
   const [theme, setTheme] = useState('#4caf50');
+  const [themeMode, setThemeMode] = useState('light');
   const [feedbackLogs, setFeedbackLogs] = useState([]);
+  const palette = palettes[themeMode];
   const [notificationSettings, setNotificationSettings] = useState(
     initialNotificationSettings
   );
@@ -95,11 +110,13 @@ export const AppProvider = ({ children }) => {
         const storedTasks = await AsyncStorage.getItem('tasks');
         const storedAnalytics = await AsyncStorage.getItem('analytics');
         const storedTheme = await AsyncStorage.getItem('theme');
+        const storedMode = await AsyncStorage.getItem('themeMode');
         const storedNotify = await AsyncStorage.getItem('notify');
         const storedFeedback = await AsyncStorage.getItem('feedbackLogs');
         if (storedTasks) setTasks(JSON.parse(storedTasks));
         if (storedAnalytics) setAnalytics(JSON.parse(storedAnalytics));
         if (storedTheme) setTheme(storedTheme);
+        if (storedMode) setThemeMode(storedMode);
         if (storedNotify) setNotificationSettings(JSON.parse(storedNotify));
         if (storedFeedback) setFeedbackLogs(JSON.parse(storedFeedback));
       } catch (e) {
@@ -117,6 +134,7 @@ export const AppProvider = ({ children }) => {
         await AsyncStorage.setItem('tasks', JSON.stringify(tasks));
         await AsyncStorage.setItem('analytics', JSON.stringify(analytics));
         await AsyncStorage.setItem('theme', theme);
+        await AsyncStorage.setItem('themeMode', themeMode);
         await AsyncStorage.setItem('notify', JSON.stringify(notificationSettings));
         await AsyncStorage.setItem('feedbackLogs', JSON.stringify(feedbackLogs));
       } catch (e) {
@@ -124,7 +142,15 @@ export const AppProvider = ({ children }) => {
       }
     };
     if (!loading) save();
-  }, [tasks, analytics, theme, notificationSettings, feedbackLogs, loading]);
+  }, [
+    tasks,
+    analytics,
+    theme,
+    themeMode,
+    notificationSettings,
+    feedbackLogs,
+    loading,
+  ]);
 
   const updatePreference = (name, preference) => {
     setUsers((prev) =>
@@ -263,6 +289,9 @@ export const AppProvider = ({ children }) => {
         error,
         theme,
         setTheme,
+        themeMode,
+        setThemeMode,
+        palette,
         analytics,
         feedbackLogs,
         notificationSettings,

--- a/app/src/screens/HomeScreen.js
+++ b/app/src/screens/HomeScreen.js
@@ -15,6 +15,7 @@ export default function HomeScreen({ navigation }) {
     loading,
     error,
     theme,
+    palette,
   } = useContext(AppContext);
   const [showNarrative, setShowNarrative] = useState(true);
   const completed = tasks.filter((t) => t.completed).length;
@@ -22,27 +23,27 @@ export default function HomeScreen({ navigation }) {
 
   if (loading) {
     return (
-      <View style={styles.center}> 
-        <ActivityIndicator size="large" />
+      <View style={[styles.center, { backgroundColor: palette.background }]}>
+        <ActivityIndicator size="large" color={palette.text} />
       </View>
     );
   }
 
   if (error) {
     return (
-      <View style={styles.center}>
-        <Text>{error}</Text>
+      <View style={[styles.center, { backgroundColor: palette.background }]}>
+        <Text style={{ color: palette.text }}>{error}</Text>
       </View>
     );
   }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Resident's Adventure Engine</Text>
+    <View style={[styles.container, { backgroundColor: palette.background }]}>
+      <Text style={[styles.title, { color: palette.text }]}>Resident's Adventure Engine</Text>
       <ProgressBar progress={progress} color={theme} />
-      <Text style={styles.tokens}>Tokens: {tokens}</Text>
+      <Text style={[styles.tokens, { color: palette.text }]}>Tokens: {tokens}</Text>
       {nextMilestone && (
-        <Text style={styles.milestone}>
+        <Text style={[styles.milestone, { color: palette.text }]}>
           {5 - (completed % 5)} tasks until next reward!
         </Text>
       )}
@@ -50,11 +51,13 @@ export default function HomeScreen({ navigation }) {
         title="View Tasks"
         onPress={() => navigation.navigate('Tasks')}
         accessibilityLabel="Go to tasks"
+        color={palette.button}
       />
       <Button
         title="Profile"
         onPress={() => navigation.navigate('Profile')}
         accessibilityLabel="Open profile screen"
+        color={palette.button}
       />
 
       <Modal
@@ -64,9 +67,14 @@ export default function HomeScreen({ navigation }) {
         onRequestClose={claimReward}
       >
         <Pressable style={styles.modalContent} onPress={claimReward}>
-          <View style={styles.modalBox}>
-            <Text style={styles.modalText}>{pendingReward}</Text>
-            <Button title="Claim" onPress={claimReward} accessibilityLabel="Claim reward" />
+          <View style={[styles.modalBox, { backgroundColor: palette.background }]}>
+            <Text style={[styles.modalText, { color: palette.text }]}>{pendingReward}</Text>
+            <Button
+              title="Claim"
+              onPress={claimReward}
+              accessibilityLabel="Claim reward"
+              color={palette.button}
+            />
           </View>
         </Pressable>
       </Modal>
@@ -81,9 +89,14 @@ export default function HomeScreen({ navigation }) {
           style={styles.modalContent}
           onPress={() => setShowNarrative(false)}
         >
-          <View style={styles.modalBox}>
-            <Text style={styles.modalText}>{storySegments[storyStep]}</Text>
-            <Button title="Close" onPress={() => setShowNarrative(false)} accessibilityLabel="Close narrative" />
+          <View style={[styles.modalBox, { backgroundColor: palette.background }]}>
+            <Text style={[styles.modalText, { color: palette.text }]}>{storySegments[storyStep]}</Text>
+            <Button
+              title="Close"
+              onPress={() => setShowNarrative(false)}
+              accessibilityLabel="Close narrative"
+              color={palette.button}
+            />
           </View>
         </Pressable>
       </Modal>
@@ -115,7 +128,6 @@ const styles = StyleSheet.create({
   milestone: {
     fontSize: 14,
     marginBottom: 10,
-    color: '#555',
   },
   modalContent: {
     flex: 1,
@@ -125,7 +137,6 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   modalBox: {
-    backgroundColor: '#fff',
     padding: 20,
     alignItems: 'center',
     width: '80%',

--- a/app/src/screens/ProfileScreen.js
+++ b/app/src/screens/ProfileScreen.js
@@ -8,6 +8,7 @@ import {
   Pressable,
   Share,
   Linking,
+  Switch,
 } from 'react-native';
 import { AppContext } from '../context/AppContext';
 
@@ -19,6 +20,9 @@ export default function ProfileScreen() {
     updatePreference,
     setTheme,
     theme,
+    themeMode,
+    setThemeMode,
+    palette,
     analytics,
     tasks,
     notificationSettings,
@@ -62,14 +66,14 @@ export default function ProfileScreen() {
     Linking.openURL('https://example.com/feedback');
   };
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Profile</Text>
-      <Text>Tokens: {tokens}</Text>
-      <Text>Progress: {(progress * 100).toFixed(0)}%</Text>
+    <ScrollView contentContainerStyle={[styles.container, { backgroundColor: palette.background }]}>
+      <Text style={[styles.title, { color: palette.text }]}>Profile</Text>
+      <Text style={{ color: palette.text }}>Tokens: {tokens}</Text>
+      <Text style={{ color: palette.text }}>Progress: {(progress * 100).toFixed(0)}%</Text>
       {users.map((u) => (
         <View key={u.name} style={styles.userSection}>
-          <Text style={styles.userName}>{u.name}</Text>
-          <Text>Completed: {u.tasksCompleted}</Text>
+          <Text style={[styles.userName, { color: palette.text }]}>{u.name}</Text>
+          <Text style={{ color: palette.text }}>Completed: {u.tasksCompleted}</Text>
           <TextInput
             style={styles.input}
             placeholder="Preference"
@@ -80,18 +84,24 @@ export default function ProfileScreen() {
       ))}
 
       <View style={styles.analytics}>
-        <Text>All-time tasks completed: {analytics.tasksCompleted}</Text>
-        <Text>Rewards claimed: {analytics.rewardsClaimed}</Text>
-        <Text>Feedback submissions: {feedbackLogs.length}</Text>
+        <Text style={{ color: palette.text }}>
+          All-time tasks completed: {analytics.tasksCompleted}
+        </Text>
+        <Text style={{ color: palette.text }}>
+          Rewards claimed: {analytics.rewardsClaimed}
+        </Text>
+        <Text style={{ color: palette.text }}>
+          Feedback submissions: {feedbackLogs.length}
+        </Text>
         {feedbackLogs.length > 0 && (
-          <Text>
-            Last feedback:{' '}
+          <Text style={{ color: palette.text }}>
+            Last feedback{' '}
             {new Date(feedbackLogs[feedbackLogs.length - 1]).toLocaleDateString()}
           </Text>
         )}
       </View>
 
-      <Text style={styles.sectionTitle}>Theme</Text>
+      <Text style={[styles.sectionTitle, { color: palette.text }]}>Theme</Text>
       <View style={styles.themeRow}>
         {['#4caf50', '#2196f3', '#ff9800'].map((c) => (
           <Pressable
@@ -103,8 +113,16 @@ export default function ProfileScreen() {
           />
         ))}
       </View>
+      <View style={styles.toggleRow}>
+        <Text style={[styles.toggleLabel, { color: palette.text }]}>Dark Mode</Text>
+        <Switch
+          value={themeMode === 'dark'}
+          onValueChange={() => setThemeMode(themeMode === 'light' ? 'dark' : 'light')}
+          accessibilityLabel="Toggle dark mode"
+        />
+      </View>
 
-      <Text style={styles.sectionTitle}>Daily Reminder</Text>
+      <Text style={[styles.sectionTitle, { color: palette.text }]}>Daily Reminder</Text>
       <View style={styles.notifyRow}>
         <TextInput
           style={styles.inputSmall}
@@ -113,7 +131,7 @@ export default function ProfileScreen() {
           onChangeText={setHour}
           accessibilityLabel="Reminder hour"
         />
-        <Text style={styles.colon}>:</Text>
+        <Text style={[styles.colon, { color: palette.text }]}>:</Text>
         <TextInput
           style={styles.inputSmall}
           value={minute}
@@ -128,25 +146,45 @@ export default function ProfileScreen() {
           accessibilityLabel="Reminder frequency"
         />
       </View>
-      <Pressable style={styles.button} onPress={saveNotification} accessibilityRole="button" accessibilityLabel="Save reminder settings">
+      <Pressable
+        style={[styles.button, { backgroundColor: palette.button }]}
+        onPress={saveNotification}
+        accessibilityRole="button"
+        accessibilityLabel="Save reminder settings"
+      >
         <Text style={styles.buttonText}>Save Reminder</Text>
       </Pressable>
 
-      <Pressable style={styles.button} onPress={exportCSV} accessibilityRole="button" accessibilityLabel="Export data as CSV">
+      <Pressable
+        style={[styles.button, { backgroundColor: palette.button }]}
+        onPress={exportCSV}
+        accessibilityRole="button"
+        accessibilityLabel="Export data as CSV"
+      >
         <Text style={styles.buttonText}>Export CSV</Text>
       </Pressable>
-      <Pressable style={styles.button} onPress={exportJSON} accessibilityRole="button" accessibilityLabel="Export data as JSON">
+      <Pressable
+        style={[styles.button, { backgroundColor: palette.button }]}
+        onPress={exportJSON}
+        accessibilityRole="button"
+        accessibilityLabel="Export data as JSON"
+      >
         <Text style={styles.buttonText}>Export JSON</Text>
       </Pressable>
       <Pressable
-        style={styles.button}
+        style={[styles.button, { backgroundColor: palette.button }]}
         onPress={exportFeedbackLogs}
         accessibilityRole="button"
         accessibilityLabel="Export feedback logs"
       >
         <Text style={styles.buttonText}>Export Feedback</Text>
       </Pressable>
-      <Pressable style={styles.button} onPress={openFeedback} accessibilityRole="button" accessibilityLabel="Open feedback form">
+      <Pressable
+        style={[styles.button, { backgroundColor: palette.button }]}
+        onPress={openFeedback}
+        accessibilityRole="button"
+        accessibilityLabel="Open feedback form"
+      >
         <Text style={styles.buttonText}>Send Feedback</Text>
       </Pressable>
     </ScrollView>
@@ -218,7 +256,6 @@ const styles = StyleSheet.create({
   button: {
     marginTop: 10,
     padding: 10,
-    backgroundColor: '#2196f3',
   },
   buttonText: {
     color: '#fff',

--- a/app/src/screens/TaskScreen.js
+++ b/app/src/screens/TaskScreen.js
@@ -12,7 +12,7 @@ import { RectButton } from 'react-native-gesture-handler';
 import { AppContext } from '../context/AppContext';
 
 export default function TaskScreen() {
-  const { tasks, toggleTask, postponeTask } = useContext(AppContext);
+  const { tasks, toggleTask, postponeTask, palette } = useContext(AppContext);
 
   const handleToggle = (id, subId) => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -40,7 +40,7 @@ export default function TaskScreen() {
   );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: palette.background }]}>
       <FlatList
         data={tasks}
         keyExtractor={(item) => item.id.toString()}
@@ -55,10 +55,10 @@ export default function TaskScreen() {
                 accessibilityRole="button"
                 accessibilityLabel={`Toggle ${item.name}`}
               >
-                <Text style={[styles.text, item.completed && styles.completed]}>
+                <Text style={[styles.text, { color: palette.text }, item.completed && styles.completed]}>
                   {item.name} ({item.assignedTo})
                 </Text>
-                <Text style={styles.meta}>
+                <Text style={[styles.meta, { color: palette.text }]}> 
                   Due: {item.dueDate} | Priority: {item.priority}
                 </Text>
               </Pressable>
@@ -71,7 +71,7 @@ export default function TaskScreen() {
                   accessibilityLabel={`Toggle ${sub.name}`}
                 >
                   <Text
-                    style={[styles.subText, sub.completed && styles.completed]}
+                    style={[styles.subText, { color: palette.text }, sub.completed && styles.completed]}
                   >
                     - {sub.name}
                   </Text>
@@ -106,7 +106,6 @@ const styles = StyleSheet.create({
   },
   meta: {
     fontSize: 12,
-    color: '#555',
   },
   completed: {
     textDecorationLine: 'line-through',


### PR DESCRIPTION
## Summary
- extend `AppContext` with `themeMode` and palettes
- store theme preference in async storage
- apply themed styles in Home, Profile and Task screens
- add dark mode toggle on Profile screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684744bbcab0832aacfa952a44cc74ed