### PR TITLE
Add linting and Jest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,31 @@
-{
-  "name": "rae",
-  "version": "1.0.0",
-  "dependencies": {
-    "expo": "^48.0.0",
-    "expo-dev-client": "*"
-  },
-  "scripts": {
-    "test": "npm test"
-  }
-}
+# Resident's Adventure Engine
+
+This project is an example React Native application built with Expo.
+
+## Development
+
+Install dependencies inside the `app` directory and run the Expo dev server:
+
+```bash
+cd app
+npm install
+npm start
+```
+
+## Testing
+
+Jest and React Native Testing Library are configured. Run tests with:
+
+```bash
+npm test
+```
+
+## Linting
+
+ESLint is set up with React Native rules. Run lint checks with:
+
+```bash
+npm run lint
+```
+
+Both commands should be executed from the `app` directory.

--- a/app/.eslintignore
+++ b/app/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+.expo/

--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+  plugins: ['@babel/plugin-transform-private-methods']
+};

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -1,0 +1,25 @@
+import js from '@eslint/js';
+import react from 'eslint-plugin-react';
+import reactNative from 'eslint-plugin-react-native';
+import parser from '@babel/eslint-parser';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.js'],
+    ignores: ['node_modules/**', '.expo/**'],
+    plugins: { react, 'react-native': reactNative },
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      parser,
+      parserOptions: {
+        requireConfigFile: false,
+        babelOptions: { presets: ['module:metro-react-native-babel-preset'] }
+      }
+    },
+    rules: {
+      'react-native/no-unused-styles': 'warn'
+    }
+  }
+];

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -1,3 +1,7 @@
 module.exports = {
-  preset: 'react-native'
+  preset: 'react-native',
+  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native|@react-navigation|expo(nent)?|@expo|expo-.*)/'
+  ]
 };

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "test": "jest --passWithNoTests"
+    "test": "jest",
+    "lint": "eslint src --ext .js,.jsx"
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
@@ -15,6 +16,7 @@
     "@react-navigation/native": "^7.1.10",
     "@react-navigation/native-stack": "^7.3.14",
     "expo": "~53.0.10",
+    "expo-dev-client": "~5.2.0",
     "expo-notifications": "^0.31.3",
     "expo-status-bar": "~2.2.3",
     "expo-updates": "^0.28.14",
@@ -24,13 +26,20 @@
     "react-native-gesture-handler": "^2.25.0",
     "react-native-safe-area-context": "^5.4.1",
     "react-native-screens": "^4.11.1",
-    "react-native-web": "^0.20.0",
-    "expo-dev-client": "~5.2.0"
+    "react-native-web": "^0.20.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@babel/eslint-parser": "^7.27.5",
+    "@babel/plugin-transform-private-methods": "^7.27.1",
+    "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^12.9.0",
+    "eslint": "^9.28.0",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-native": "^5.0.0",
     "jest": "^29.7.0",
+    "jest-expo": "^53.0.7",
+    "metro-react-native-babel-preset": "^0.77.0",
     "react-test-renderer": "^19.0.0"
   },
   "private": true

--- a/app/src/components/__tests__/ProgressBar.test.js
+++ b/app/src/components/__tests__/ProgressBar.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ProgressBar } from '../ProgressBar';
+
+test('renders with correct progress', () => {
+  const { getByA11yRole } = render(<ProgressBar progress={0.5} />);
+  const bar = getByA11yRole('progressbar');
+  expect(bar.props.accessibilityValue.now).toBe(50);
+});


### PR DESCRIPTION
## Summary
- configure Jest for React Native Testing Library
- add sample test for `ProgressBar`
- enable ESLint with React Native rules
- document how to run tests and linting

## Testing
- `npm test` *(fails: Class private methods plugin mismatch)*
- `npm run lint` *(fails: 35 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684798966af4832aa9c8e96ab2e92d81